### PR TITLE
fix cl not in its child's parent list

### DIFF
--- a/src/deeponto/onto/prune/pruning.py
+++ b/src/deeponto/onto/prune/pruning.py
@@ -107,6 +107,9 @@ class OntoPruner:
             print(f"Link the parents and children of the isolated class: {cl.iri}")
             for ch in children:
                 ch.is_a += parents
-                ch.is_a.remove(cl)  # isolate cl from its child
+                if cl in ch.is_a:
+                    ch.is_a.remove(cl)  # isolate cl from its child
+                else:
+                    print('cl', cl, 'not in child\'s parents:', ch.is_a)
         # isolate cl from its parents
         cl.is_a.clear()


### PR DESCRIPTION
example for SNOMEDCT-US-20170901: 
cl id.246061005 not in child's parents: [owl.ObjectProperty, id.900000000000441003]